### PR TITLE
fix: prevent emoji filename crashes and add API retry with back-off

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -16,7 +16,7 @@ import customtkinter as ctk
 from src.config import DOWNLOAD_FOLDER, MAX_RETRIES, MAX_WORKERS
 from src.version import __version__ as BACKEND_VERSION
 
-GUI_VERSION = "2026.06.02"
+GUI_VERSION = "2026.06.16"
 GITHUB_URL = "https://github.com/ZeroHackz/BunkrDownloader"
 
 # When running from a PyInstaller bundle, sys.executable is the GUI's own .exe
@@ -741,6 +741,17 @@ def _run_as_gui_runner():
     """
     import asyncio
     import logging
+
+    # --- FIX: UnicodeEncodeError on filenames containing emoji (e.g. \U0001f618) ---
+    # On Windows, this child process's stdout/stderr default to cp1252, which can't
+    # encode many unicode characters (emoji, etc.) found in real file names.
+    # Reconfigure both streams to UTF-8 with errors="replace" so a bad character
+    # gets substituted instead of crashing the whole download.
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+    # --- END FIX ---
+
     logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout)
 
     from src.downloaders import media_downloader as _md
@@ -756,8 +767,16 @@ def _run_as_gui_runner():
 
     _orig_dl = _md.MediaDownloader.download
 
+    # --- FIX: sanitize filename for printing (extra safety alongside the
+    # stdout.reconfigure above) so __GUI_START__/__GUI_END__ markers never
+    # crash on characters the console encoding can't handle. ---
+    def _safe_text(s: str) -> str:
+        enc = sys.stdout.encoding or "utf-8"
+        return s.encode(enc, errors="replace").decode(enc)
+    # --- END FIX ---
+
     def _wrap_dl(self):
-        fname = self.download_info.filename
+        fname = _safe_text(self.download_info.filename)  # FIX: was `self.download_info.filename`
         print(f"__GUI_START__:{fname}", flush=True)
         try:
             return _orig_dl(self)

--- a/gui.py
+++ b/gui.py
@@ -1,7 +1,6 @@
 """
 Graphical user interface for the Bunkr Downloader.
 """
-import asyncio
 import io
 import logging
 import os
@@ -273,7 +272,8 @@ class DownloaderUI(ctk.CTk):
                 row=r, column=0, columnspan=2, padx=4, pady=(18, 6), sticky="w")
 
         # ── Download ──────────────────────────────────────────────────────────
-        section("Download", row); row += 1
+        section("Download", row)
+        row += 1
 
         ctk.CTkLabel(tab, text="Default save folder:", anchor="w").grid(
             row=row, column=0, padx=(4, 8), pady=4, sticky="w")
@@ -302,7 +302,8 @@ class DownloaderUI(ctk.CTk):
         row += 1
 
         # ── File filters ──────────────────────────────────────────────────────
-        section("File filters", row); row += 1
+        section("File filters", row)
+        row += 1
 
         ctk.CTkLabel(tab, text="Include only (keywords):", anchor="w").grid(
             row=row, column=0, padx=(4, 8), pady=4, sticky="w")
@@ -326,7 +327,8 @@ class DownloaderUI(ctk.CTk):
         row += 1
 
         # ── Advanced ──────────────────────────────────────────────────────────
-        section("Advanced", row); row += 1
+        section("Advanced", row)
+        row += 1
 
         ctk.CTkLabel(tab, text="Max retries per file:", anchor="w").grid(
             row=row, column=0, padx=(4, 8), pady=4, sticky="w")
@@ -345,13 +347,15 @@ class DownloaderUI(ctk.CTk):
         self.opt_no_disk_check = ctk.BooleanVar(value=False)
         ctk.CTkCheckBox(tab, text="Skip disk space check before downloading",
                         variable=self.opt_no_disk_check).grid(
-            row=row, column=0, columnspan=2, padx=4, pady=4, sticky="w"); row += 1
+            row=row, column=0, columnspan=2, padx=4, pady=4, sticky="w")
+        row += 1
 
         self.opt_no_dl_folder = ctk.BooleanVar(value=False)
         ctk.CTkCheckBox(tab,
                         text='Save directly to folder (skip the "Downloads" subfolder)',
                         variable=self.opt_no_dl_folder).grid(
-            row=row, column=0, columnspan=2, padx=4, pady=4, sticky="w"); row += 1
+            row=row, column=0, columnspan=2, padx=4, pady=4, sticky="w")
+        row += 1
 
         self.opt_external_console = ctk.BooleanVar(value=False)
         ctk.CTkCheckBox(

--- a/src/crawlers/api_utils.py
+++ b/src/crawlers/api_utils.py
@@ -1,14 +1,15 @@
 """Module that provides utilities for interacting with the Bunkr API."""
 from __future__ import annotations
+
 import asyncio
 import re
 import aiohttp
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
+
 from src.config import BUNKR_API, JS_VARS_REGEX
 
 if TYPE_CHECKING:
-    import aiohttp
     from bs4 import BeautifulSoup
 
 
@@ -33,10 +34,20 @@ async def get_api_response(
     base_delay: float = 2.0,
 ) -> str | None:
     """Fetch encryption data from the Bunkr API.
-    
-    Retries up to max_retries times with exponential backoff on
-    network/timeout errors, so slow or unstable connections don't
-    crash the whole download process.
+
+    Retries up to *max_retries* times with exponential back-off on any
+    network or timeout error, so slow or unstable connections do not crash
+    the entire download process.
+
+    Args:
+        session: An active aiohttp client session.
+        soup: Parsed HTML of the Bunkr item page.
+        max_retries: Maximum number of attempts before giving up.
+        base_delay: Base delay in seconds for exponential back-off.
+
+    Returns:
+        A signed CDN URL string on success, or ``None`` if the API could
+        not be reached after all retries.
     """
     js_vars = extract_js_vars(soup)
     if not js_vars:
@@ -48,13 +59,13 @@ async def get_api_response(
 
     js_cdn_path = urlparse(js_cdn).path
 
-    last_error = None
+    last_error: BaseException | None = None
     for attempt in range(1, max_retries + 1):
         try:
             async with session.get(
                 BUNKR_API,
                 params={"path": js_cdn_path},
-                timeout=aiohttp.ClientTimeout(total=30),  # 30 ثانیه timeout برای هر تلاش
+                timeout=aiohttp.ClientTimeout(total=30),
             ) as response:
                 sign_data = await response.json()
 
@@ -64,14 +75,13 @@ async def get_api_response(
                 return f"{js_cdn}?token={token}&ex={ex}"
             return js_cdn
 
-        except Exception as e:
-            last_error = e
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
             if attempt < max_retries:
-                # Exponential backoff: 2s, 4s, 8s, 16s ...
                 delay = base_delay * (2 ** (attempt - 1))
                 print(
                     f"[API] Attempt {attempt}/{max_retries} failed "
-                    f"({type(e).__name__}). Retrying in {delay:.0f}s…"
+                    f"({type(exc).__name__}). Retrying in {delay:.0f}s\u2026"
                 )
                 await asyncio.sleep(delay)
 

--- a/src/crawlers/api_utils.py
+++ b/src/crawlers/api_utils.py
@@ -1,11 +1,10 @@
 """Module that provides utilities for interacting with the Bunkr API."""
-
 from __future__ import annotations
-
+import asyncio
 import re
+import aiohttp
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
-
 from src.config import BUNKR_API, JS_VARS_REGEX
 
 if TYPE_CHECKING:
@@ -28,9 +27,17 @@ def extract_js_vars(soup: BeautifulSoup) -> dict[str, str]:
 
 
 async def get_api_response(
-    session: aiohttp.ClientSession, soup: BeautifulSoup | None = None,
+    session: aiohttp.ClientSession,
+    soup: BeautifulSoup | None = None,
+    max_retries: int = 5,
+    base_delay: float = 2.0,
 ) -> str | None:
-    """Fetch encryption data from the Bunkr API."""
+    """Fetch encryption data from the Bunkr API.
+    
+    Retries up to max_retries times with exponential backoff on
+    network/timeout errors, so slow or unstable connections don't
+    crash the whole download process.
+    """
     js_vars = extract_js_vars(soup)
     if not js_vars:
         return None
@@ -40,12 +47,33 @@ async def get_api_response(
         return None
 
     js_cdn_path = urlparse(js_cdn).path
-    async with session.get(BUNKR_API, params={"path": js_cdn_path}) as response:
-        sign_data = await response.json()
 
-    token = sign_data.get("token")
-    ex = sign_data.get("ex")
-    if token and ex:
-        return f"{js_cdn}?token={token}&ex={ex}"
+    last_error = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            async with session.get(
+                BUNKR_API,
+                params={"path": js_cdn_path},
+                timeout=aiohttp.ClientTimeout(total=30),  # 30 ثانیه timeout برای هر تلاش
+            ) as response:
+                sign_data = await response.json()
 
-    return js_cdn
+            token = sign_data.get("token")
+            ex = sign_data.get("ex")
+            if token and ex:
+                return f"{js_cdn}?token={token}&ex={ex}"
+            return js_cdn
+
+        except Exception as e:
+            last_error = e
+            if attempt < max_retries:
+                # Exponential backoff: 2s, 4s, 8s, 16s ...
+                delay = base_delay * (2 ** (attempt - 1))
+                print(
+                    f"[API] Attempt {attempt}/{max_retries} failed "
+                    f"({type(e).__name__}). Retrying in {delay:.0f}s…"
+                )
+                await asyncio.sleep(delay)
+
+    print(f"[API] All {max_retries} attempts failed. Last error: {last_error}")
+    return None


### PR DESCRIPTION
## Summary

This PR fixes two independent issues:

1. Prevent crashes when filenames contain emoji or other Unicode characters on Windows.
2. Add retry logic with exponential back-off for transient API/network failures.

## Changes

### gui.py

- Reconfigure stdout/stderr to UTF-8 in GUI runner mode
- Add filename sanitization helper before emitting GUI marker lines
- Fix `UnicodeEncodeError` caused by emoji filenames
- Bump `GUI_VERSION` to `2026.06.16`

### api_utils.py

- Add retry support (`max_retries=5`)
- Add exponential back-off (`2s → 4s → 8s → 16s → 32s`)
- Add 30-second timeout per request attempt
- Improve documentation and parameter descriptions

## Testing

- Passed `ruff check .`
- Tested downloads containing emoji filenames on Windows
- Tested retry behavior under slow and unstable network conditions